### PR TITLE
Use python3 as default python

### DIFF
--- a/Docker_container/elisa.dockerfile
+++ b/Docker_container/elisa.dockerfile
@@ -2,7 +2,7 @@ FROM debian:buster-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN set -x && apt-get update && apt-get upgrade -y \
-  && apt-get install -y curl python\
+  && apt-get install -y curl python \
     gawk wget git-core diffstat unzip texinfo gcc-multilib \
      build-essential chrpath socat libsdl1.2-dev xterm \
       cpio file locales lz4 zstd procps libtinfo5
@@ -38,7 +38,7 @@ if [ ! -d \$AGL_TOP/needlefish ]; then\n\
 	repo sync\n\
 	git clone https://github.com/elisa-tech/meta-elisa.git\n\
 fi" > /bin/setup_elisa.sh
-RUN chmod a+x /bin/setup_elisa.sh
+RUN chmod a+x /bin/setup_elisa.sh && update-alternatives --install /usr/bin/python python /usr/bin/python3.7m 3
 
 ARG UNAME=elisa
 ARG UID=1000


### PR DESCRIPTION
Latest 'repo' is python3 based, so a clean build with latest repo is failing and the failure can be seen at https://gitlab.com/elisa-tech/meta-elisa-ci/-/jobs/5879131538.
The CI is working only becasue its using the cached copy of repo.

A docker build from this PR can be seen at https://gitlab.com/elisa-tech/docker-image/-/jobs/5882023050
A clean build from the generated docker can be seen at https://gitlab.com/elisa-tech/meta-elisa-ci/-/jobs/5882057289